### PR TITLE
breaking: Add support for conditional migrations

### DIFF
--- a/migration/src/main/kotlin/com/boswelja/migration/ListExtensions.kt
+++ b/migration/src/main/kotlin/com/boswelja/migration/ListExtensions.kt
@@ -7,7 +7,7 @@ package com.boswelja.migration
  * @return a [Pair] of [List]s, where [Pair.first] contains all elements matching [predicate], and
  * [Pair.second] contains all elements not matching [predicate].
  */
-fun <T> List<T>.separate(predicate: (T) -> Boolean): Pair<List<T>, List<T>> {
+suspend fun <T> List<T>.separate(predicate: suspend (T) -> Boolean): Pair<List<T>, List<T>> {
     val matching = mutableListOf<T>()
     val notMatching = mutableListOf<T>()
 

--- a/migration/src/main/kotlin/com/boswelja/migration/Migration.kt
+++ b/migration/src/main/kotlin/com/boswelja/migration/Migration.kt
@@ -31,9 +31,9 @@ interface Migration {
  */
 abstract class VersionMigration(
     val fromVersion: Int,
-    override val toVersion: Int
+    final override val toVersion: Int
 ) : Migration {
-    override suspend fun shouldMigrate(fromVersion: Int): Boolean {
+    final override suspend fun shouldMigrate(fromVersion: Int): Boolean {
         // Run this migration if fromVersion is the same as the version provided by the user
         return fromVersion == this.fromVersion
     }
@@ -44,5 +44,5 @@ abstract class VersionMigration(
  * @param toVersion The version to migrate to.
  */
 abstract class ConditionalMigration(
-    override val toVersion: Int
+    final override val toVersion: Int
 ) : Migration

--- a/migration/src/main/kotlin/com/boswelja/migration/Migration.kt
+++ b/migration/src/main/kotlin/com/boswelja/migration/Migration.kt
@@ -1,18 +1,48 @@
 package com.boswelja.migration
 
 /**
- * Defines a migration from one version to the next.
- * @param fromVersion The old version to migrate from.
- * @param toVersion The version to migrate to.
+ * An interface that all Migrations must implement, to be supported by [Migrator].
  */
-abstract class Migration(
-    val fromVersion: Int,
+interface Migration {
+
+    /**
+     * The version the system will be at after applying the migration.
+     */
     val toVersion: Int
-) {
 
     /**
      * Performs migration logic.
      * @return true if migrating was successful, false otherwise.
      */
-    abstract suspend fun migrate(): Boolean
+    suspend fun migrate(): Boolean
+
+    /**
+     * Whether this migration should be run.
+     * @param fromVersion The version we are trying to migrate from.
+     * @return true if this migration should be run, false otherwise.
+     */
+    suspend fun shouldMigrate(fromVersion: Int): Boolean
 }
+
+/**
+ * Defines a migration from one version to the next.
+ * @param fromVersion The old version to migrate from.
+ * @param toVersion The version to migrate to.
+ */
+abstract class VersionMigration(
+    val fromVersion: Int,
+    override val toVersion: Int
+) : Migration {
+    override suspend fun shouldMigrate(fromVersion: Int): Boolean {
+        // Run this migration if fromVersion is the same as the version provided by the user
+        return fromVersion == this.fromVersion
+    }
+}
+
+/**
+ * Defines a migration that should be run if some condition is met.
+ * @param toVersion The version to migrate to.
+ */
+abstract class ConditionalMigration(
+    override val toVersion: Int
+) : Migration

--- a/migration/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -45,7 +45,7 @@ abstract class Migrator(
      * @param fromVersion The version to build a migration map from.
      * @return A [List] of ordered [Migration]s that can be run to reach [currentVersion].
      */
-    internal fun buildMigrationMap(
+    internal suspend fun buildMigrationMap(
         migrations: List<Migration>,
         fromVersion: Int
     ): List<Migration> {
@@ -53,7 +53,7 @@ abstract class Migrator(
 
         // Get next available migrations, and all remaining migrations
         val (migrationsFromOldVersion, remainingMigrations) = migrations.separate {
-            it.fromVersion == fromVersion
+            it.shouldMigrate(fromVersion)
         }
 
         // Determine next migration and add to migration map

--- a/migration/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
+++ b/migration/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
@@ -4,7 +4,7 @@ class ConcreteMigrator(
     private val oldVersion: Int,
     currentVersion: Int,
     abortOnError: Boolean = true,
-    migrations: List<Migration>
+    migrations: List<VersionMigration>
 ) : Migrator(currentVersion, abortOnError, migrations) {
     override suspend fun getOldVersion(): Int = oldVersion
 }

--- a/migration/src/test/kotlin/com/boswelja/migration/ListExtensionsKtTest.kt
+++ b/migration/src/test/kotlin/com/boswelja/migration/ListExtensionsKtTest.kt
@@ -1,5 +1,6 @@
 package com.boswelja.migration
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
@@ -11,7 +12,7 @@ class ListExtensionsKtTest {
     @Test
     fun `separate handles empty list`() {
         val list = emptyList<String>()
-        val result = list.separate { it.isEmpty() }
+        val result = runBlocking { list.separate { it.isEmpty() } }
 
         expectThat(result.first).isEmpty()
         expectThat(result.second).isEmpty()
@@ -21,7 +22,7 @@ class ListExtensionsKtTest {
     fun `separate handles all elements matching predicate`() {
         val list = List(10) { 1 }
 
-        val result = list.separate { it == 1 }
+        val result = runBlocking { list.separate { it == 1 } }
 
         expectThat(result.first).containsExactlyInAnyOrder(list)
         expectThat(result.second).isEmpty()
@@ -31,7 +32,7 @@ class ListExtensionsKtTest {
     fun `separate handles all elements not matching predicate`() {
         val list = List(10) { 1 }
 
-        val result = list.separate { it != 1 }
+        val result = runBlocking { list.separate { it != 1 } }
 
         expectThat(result.first).isEmpty()
         expectThat(result.second).containsExactlyInAnyOrder(list)
@@ -41,7 +42,7 @@ class ListExtensionsKtTest {
     fun `separate handles mix of elements matching predicates`() {
         val list = List(10) { if (it % 2 == 0) 1 else 0 }
 
-        val result = list.separate { it == 1 }
+        val result = runBlocking { list.separate { it == 1 } }
 
         result.first.forEach {
             expectThat(it).isEqualTo(1)

--- a/migration/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
+++ b/migration/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
@@ -15,7 +15,7 @@ class MigratorTest {
     @Test
     fun `migrate() succeeds with one migration`() {
         // Set up dummy migrations
-        val migration = object : Migration(1, 2) {
+        val migration = object : VersionMigration(1, 2) {
             override suspend fun migrate(): Boolean {
                 return true
             }
@@ -34,7 +34,7 @@ class MigratorTest {
     @Test
     fun `migrate() fails when migration fails`() {
         // Set up dummy migrations
-        val migration = object : Migration(1, 2) {
+        val migration = object : VersionMigration(1, 2) {
             override suspend fun migrate(): Boolean {
                 return false
             }
@@ -55,17 +55,17 @@ class MigratorTest {
         // Create some ordered migrations
         val orderedMigrations = listOf(
             spyk(
-                object : Migration(1, 2) {
+                object : VersionMigration(1, 2) {
                     override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
-                object : Migration(2, 3) {
+                object : VersionMigration(2, 3) {
                     override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
-                object : Migration(3, 4) {
+                object : VersionMigration(3, 4) {
                     override suspend fun migrate(): Boolean = true
                 }
             )
@@ -94,17 +94,17 @@ class MigratorTest {
         // Create some ordered migrations
         val migrations = listOf(
             spyk(
-                object : Migration(1, 2) {
+                object : VersionMigration(1, 2) {
                     override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
-                object : Migration(2, 3) {
+                object : VersionMigration(2, 3) {
                     override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
-                object : Migration(3, 4) {
+                object : VersionMigration(3, 4) {
                     override suspend fun migrate(): Boolean = true
                 }
             )
@@ -132,12 +132,12 @@ class MigratorTest {
     fun `abortOnError aborts on error when true`() {
         val migrations = listOf(
             spyk(
-                object : Migration(1, 2) {
+                object : VersionMigration(1, 2) {
                     override suspend fun migrate(): Boolean = false
                 }
             ),
             spyk(
-                object : Migration(2, 3) {
+                object : VersionMigration(2, 3) {
                     override suspend fun migrate(): Boolean = true
                 }
             )
@@ -158,12 +158,12 @@ class MigratorTest {
     fun `abortOnError continues on error when false`() {
         val migrations = listOf(
             spyk(
-                object : Migration(1, 2) {
+                object : VersionMigration(1, 2) {
                     override suspend fun migrate(): Boolean = false
                 }
             ),
             spyk(
-                object : Migration(2, 3) {
+                object : VersionMigration(2, 3) {
                     override suspend fun migrate(): Boolean = true
                 }
             )
@@ -183,10 +183,10 @@ class MigratorTest {
     @Test
     fun `migrate() returns false on error`() {
         val migrations = listOf(
-            object : Migration(1, 2) {
+            object : VersionMigration(1, 2) {
                 override suspend fun migrate(): Boolean = false
             },
-            object : Migration(2, 3) {
+            object : VersionMigration(2, 3) {
                 override suspend fun migrate(): Boolean = true
             }
         )
@@ -204,10 +204,10 @@ class MigratorTest {
     @Test
     fun `migrate() returns true on success`() {
         val migrations = listOf(
-            object : Migration(1, 2) {
+            object : VersionMigration(1, 2) {
                 override suspend fun migrate(): Boolean = true
             },
-            object : Migration(2, 3) {
+            object : VersionMigration(2, 3) {
                 override suspend fun migrate(): Boolean = true
             }
         )

--- a/migration/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
+++ b/migration/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
@@ -1,0 +1,34 @@
+package com.boswelja.migration
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class VersionMigrationTest {
+
+    @Test
+    fun `shouldMigrate returns true if the migration can be applied`() {
+        val fromVersion = 1
+        val toVersion = 2
+        val migration = object : VersionMigration(fromVersion, toVersion) {
+            override suspend fun migrate(): Boolean = true
+        }
+
+        val shouldMigrate = runBlocking { migration.shouldMigrate(fromVersion) }
+        expectThat(shouldMigrate).isTrue()
+    }
+
+    @Test
+    fun `shouldMigrate returns false if the migration cannot be applied`() {
+        val fromVersion = 1
+        val toVersion = 2
+        val migration = object : VersionMigration(fromVersion, toVersion) {
+            override suspend fun migrate(): Boolean = true
+        }
+
+        val shouldMigrate = runBlocking { migration.shouldMigrate(toVersion) }
+        expectThat(shouldMigrate).isFalse()
+    }
+}


### PR DESCRIPTION
This change should also make it easier to add logic to existing migrations, as well as create new migration types altogether.

While `Migration` still exists, it's now an interface. The direct replacement when upgrading should be `VersionMigration`