### PR TITLE
feature: Add onMigrateTo to Migrator

### DIFF
--- a/migration/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -7,7 +7,7 @@ package com.boswelja.migration
  * @param migrations The available [Migration]s to use.
  */
 abstract class Migrator(
-    private val currentVersion: Int,
+    val currentVersion: Int,
     private val abortOnError: Boolean = true,
     private val migrations: List<Migration>
 ) {

--- a/migration/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
+++ b/migration/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
@@ -6,5 +6,10 @@ class ConcreteMigrator(
     abortOnError: Boolean = true,
     migrations: List<Migration>
 ) : Migrator(currentVersion, abortOnError, migrations) {
+    var migratedTo = oldVersion
+
     override suspend fun getOldVersion(): Int = oldVersion
+    override suspend fun onMigratedTo(version: Int) {
+        migratedTo = version
+    }
 }


### PR DESCRIPTION
This provides a more accurate way of reporting the version, in the event a migration fails for example.