### PR TITLE
True conditional migrations

### DIFF
--- a/benchmark/src/main/kotlin/com/boswelja/migration/MigratorBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/boswelja/migration/MigratorBenchmark.kt
@@ -23,9 +23,9 @@ class MigratorBenchmark {
     final val fromVersion = 1
     final val toVersion = 100
     // Create some basic migrations that do nothing
-    private val migrations = (fromVersion..toVersion).map { fromVer ->
+    private val versionedMigrations = (fromVersion..toVersion).map { fromVer ->
         object : VersionMigration(fromVer, fromVer + 1) {
-            override suspend fun migrate(): Result = Result.SUCCESS
+            override suspend fun migrate(): Boolean = true
         }
     }
 
@@ -35,7 +35,7 @@ class MigratorBenchmark {
     fun setUp() {
         migrator = object : Migrator(
             currentVersion = toVersion,
-            migrations = migrations
+            migrations = versionedMigrations
         ) {
             override suspend fun onMigratedTo(version: Int) {
                 // Do nothing
@@ -51,10 +51,10 @@ class MigratorBenchmark {
     }
 
     @Benchmark
-    fun buildMigrationMapBenchmark(): Unit = runBlocking {
-        migrator.buildMigrationMap(
-            migrations,
-            fromVersion
+    fun runVersionedMigrationsBenchmark(): Unit = runBlocking {
+        migrator.runVersionedMigrations(
+            fromVersion,
+            versionedMigrations
         )
     }
 }

--- a/benchmark/src/main/kotlin/com/boswelja/migration/MigratorBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/boswelja/migration/MigratorBenchmark.kt
@@ -28,6 +28,12 @@ class MigratorBenchmark {
             override suspend fun migrate(): Boolean = true
         }
     }
+    private val constantMigrations = (fromVersion..toVersion).map {
+        object : ConditionalMigration() {
+            override suspend fun shouldMigrate(fromVersion: Int): Boolean = true
+            override suspend fun migrate(): Boolean = true
+        }
+    }
 
     private lateinit var migrator: Migrator
 
@@ -35,7 +41,7 @@ class MigratorBenchmark {
     fun setUp() {
         migrator = object : Migrator(
             currentVersion = toVersion,
-            migrations = versionedMigrations
+            migrations = versionedMigrations + constantMigrations
         ) {
             override suspend fun onMigratedTo(version: Int) {
                 // Do nothing
@@ -55,6 +61,14 @@ class MigratorBenchmark {
         migrator.runVersionedMigrations(
             fromVersion,
             versionedMigrations
+        )
+    }
+
+    @Benchmark
+    fun runConstantMigrationsBenchmark(): Unit = runBlocking {
+        migrator.runConstantMigrations(
+            fromVersion,
+            constantMigrations
         )
     }
 }

--- a/benchmark/src/main/kotlin/com/boswelja/migration/ResultBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/boswelja/migration/ResultBenchmark.kt
@@ -1,0 +1,69 @@
+package com.boswelja.migration
+
+import kotlinx.benchmark.Mode
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.util.concurrent.TimeUnit
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+class ResultBenchmark {
+
+    @Benchmark
+    fun combineSuccessResultsBenchmark() {
+        combineResults(
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS
+        )
+    }
+
+    @Benchmark
+    fun combineFailedResultsBenchmark() {
+        combineResults(
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.FAILED
+        )
+    }
+
+    @Benchmark
+    fun combineNotNeededResultsBenchmark() {
+        combineResults(
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED
+        )
+    }
+}

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migration.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migration.kt
@@ -6,9 +6,10 @@ package com.boswelja.migration
 interface Migration {
 
     /**
-     * The version the system will be at after applying the migration.
+     * The version the system will be at after applying the migration, or null if the
+     * version shouldn't change.
      */
-    val toVersion: Int
+    val toVersion: Int?
 
     /**
      * Performs migration logic.
@@ -41,8 +42,7 @@ abstract class VersionMigration(
 
 /**
  * Defines a migration that should be run if some condition is met.
- * @param toVersion The version to migrate to.
  */
-abstract class ConditionalMigration(
-    final override val toVersion: Int
-) : Migration
+abstract class ConditionalMigration : Migration {
+    override val toVersion: Int? = null
+}

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migration.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migration.kt
@@ -13,9 +13,9 @@ interface Migration {
 
     /**
      * Performs migration logic.
-     * @return See [Result].
+     * @return true if migration was successful, false otherwise.
      */
-    suspend fun migrate(): Result
+    suspend fun migrate(): Boolean
 
     /**
      * Whether this migration should be run.

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -82,7 +82,6 @@ abstract class Migrator(
         }
     }
 
-
     /**
      * A recursive function to build a list of [Migration]s to be run in a sequential order. Note
      * this will throw [IllegalArgumentException] if a migration cannot be found from a version.

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -122,13 +122,16 @@ abstract class Migrator(
      * @return the combined result.
      */
     internal fun combineResults(vararg results: Result): Result {
-        val result = if (results.all { it == Result.SUCCESS }) {
-            Result.SUCCESS
-        } else if (results.all { it == Result.NOT_NEEDED }) {
-            Result.NOT_NEEDED
-        } else {
-            Result.FAILED
+        return when {
+            results.all { it == Result.SUCCESS } -> {
+                Result.SUCCESS
+            }
+            results.all { it == Result.NOT_NEEDED } -> {
+                Result.NOT_NEEDED
+            }
+            else -> {
+                Result.FAILED
+            }
         }
-        return result
     }
 }

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -70,7 +70,7 @@ abstract class Migrator(
                 result = Result.FAILED
                 // If abort on error is true, return result now
                 if (abortOnError) {
-                    return@forEach
+                    return result
                 }
             }
         }
@@ -111,27 +111,10 @@ abstract class Migrator(
             version = migration.toVersion!!
         }
 
-        onMigratedTo(version)
+        if (result != Result.NOT_NEEDED) {
+            onMigratedTo(version)
+        }
 
         return result
-    }
-
-    /**
-     * Combine a number of [Result]s into a single [Result].
-     * @param results The [Result]s to combine.
-     * @return the combined result.
-     */
-    internal fun combineResults(vararg results: Result): Result {
-        return when {
-            results.all { it == Result.SUCCESS } -> {
-                Result.SUCCESS
-            }
-            results.all { it == Result.NOT_NEEDED } -> {
-                Result.NOT_NEEDED
-            }
-            else -> {
-                Result.FAILED
-            }
-        }
     }
 }

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Migrator.kt
@@ -34,12 +34,12 @@ abstract class Migrator(
         val (versionMigrations, constantMigrations) = migrations.separate { it.toVersion != null }
 
         // Handle constant migrations
-        runConstantMigrations(oldVersion, constantMigrations)
+        val constantsResult = runConstantMigrations(oldVersion, constantMigrations)
 
         // Handle versioned migrations
-        val result = runVersionedMigrations(oldVersion, versionMigrations)
+        val versionedResult = runVersionedMigrations(oldVersion, versionMigrations)
 
-        return result
+        return combineResults(constantsResult, versionedResult)
     }
 
     /**
@@ -113,6 +113,22 @@ abstract class Migrator(
 
         onMigratedTo(version)
 
+        return result
+    }
+
+    /**
+     * Combine a number of [Result]s into a single [Result].
+     * @param results The [Result]s to combine.
+     * @return the combined result.
+     */
+    internal fun combineResults(vararg results: Result): Result {
+        val result = if (results.all { it == Result.SUCCESS }) {
+            Result.SUCCESS
+        } else if (results.all { it == Result.NOT_NEEDED }) {
+            Result.NOT_NEEDED
+        } else {
+            Result.FAILED
+        }
         return result
     }
 }

--- a/migration-core/src/main/kotlin/com/boswelja/migration/Result.kt
+++ b/migration-core/src/main/kotlin/com/boswelja/migration/Result.kt
@@ -16,3 +16,22 @@ enum class Result {
      */
     NOT_NEEDED
 }
+
+/**
+ * Combine a number of [Result]s into a single [Result].
+ * @param results The [Result]s to combine.
+ * @return the combined result.
+ */
+fun combineResults(vararg results: Result): Result {
+    return when {
+        results.all { it == Result.SUCCESS } -> {
+            Result.SUCCESS
+        }
+        results.all { it == Result.NOT_NEEDED } -> {
+            Result.NOT_NEEDED
+        }
+        else -> {
+            Result.FAILED
+        }
+    }
+}

--- a/migration-core/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/ConcreteMigrator.kt
@@ -6,7 +6,7 @@ class ConcreteMigrator(
     abortOnError: Boolean = true,
     migrations: List<Migration>
 ) : Migrator(currentVersion, abortOnError, migrations) {
-    var migratedTo = oldVersion
+    var migratedTo: Int? = null
 
     override suspend fun getOldVersion(): Int = oldVersion
     override suspend fun onMigratedTo(version: Int) {

--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
@@ -1,0 +1,37 @@
+package com.boswelja.migration
+
+class ConcreteVersionMigration(
+    fromVersion: Int,
+    toVersion: Int,
+    private val migrateResult: (fromVersion: Int) -> Boolean
+) : VersionMigration(fromVersion, toVersion) {
+    override suspend fun migrate(): Boolean = migrateResult(fromVersion)
+}
+
+class ConcreteConstatntMigration(
+    private val shouldMigrateResult: (fromVersion: Int) -> Boolean,
+    private val migrateResult: () -> Boolean
+) : Migration {
+    override val toVersion: Int? = null
+    override suspend fun shouldMigrate(fromVersion: Int): Boolean = shouldMigrateResult(fromVersion)
+    override suspend fun migrate(): Boolean = migrateResult()
+}
+
+fun createVersionedMigrations(
+    fromVersion: Int,
+    toVersion: Int,
+    migrateResult: (fromVersion: Int) -> Boolean
+) = (fromVersion..toVersion).map { fromVer ->
+    ConcreteVersionMigration(fromVer, fromVer + 1, migrateResult)
+}
+
+fun createConstantMigrations(
+    count: Int,
+    shouldMigrate: (index: Int) -> Boolean,
+    migrateResult: (index: Int) -> Boolean
+) = (0 until count).map { index ->
+    ConcreteConstatntMigration(
+        shouldMigrate,
+        { migrateResult(index) }
+    )
+}

--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
@@ -1,5 +1,7 @@
 package com.boswelja.migration
 
+import io.mockk.spyk
+
 class ConcreteVersionMigration(
     fromVersion: Int,
     toVersion: Int,
@@ -22,7 +24,7 @@ fun createVersionedMigrations(
     toVersion: Int,
     migrateResult: (fromVersion: Int) -> Boolean
 ) = (fromVersion..toVersion).map { fromVer ->
-    ConcreteVersionMigration(fromVer, fromVer + 1, migrateResult)
+    spyk(ConcreteVersionMigration(fromVer, fromVer + 1, migrateResult))
 }
 
 fun createConstantMigrations(
@@ -30,8 +32,10 @@ fun createConstantMigrations(
     shouldMigrate: (index: Int) -> Boolean,
     migrateResult: (index: Int) -> Boolean
 ) = (0 until count).map { index ->
-    ConcreteConstatntMigration(
-        shouldMigrate,
-        { migrateResult(index) }
+    spyk(
+        ConcreteConstatntMigration(
+            shouldMigrate,
+            { migrateResult(index) }
+        )
     )
 }

--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
@@ -15,9 +15,7 @@ class MigratorTest {
     fun `migrate() succeeds with one migration`() {
         // Set up dummy migrations
         val migration = object : VersionMigration(1, 2) {
-            override suspend fun migrate(): Result {
-                return Result.SUCCESS
-            }
+            override suspend fun migrate(): Boolean = true
         }
         val migrator = ConcreteMigrator(
             oldVersion = 1,
@@ -34,9 +32,7 @@ class MigratorTest {
     fun `migrate() fails when migration fails`() {
         // Set up dummy migrations
         val migration = object : VersionMigration(1, 2) {
-            override suspend fun migrate(): Result {
-                return Result.FAILED
-            }
+            override suspend fun migrate(): Boolean = false
         }
         val migrator = ConcreteMigrator(
             oldVersion = 1,
@@ -55,17 +51,17 @@ class MigratorTest {
         val orderedMigrations = listOf(
             spyk(
                 object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
                 object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
                 object : VersionMigration(3, 4) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             )
         )
@@ -109,17 +105,17 @@ class MigratorTest {
         val migrations = listOf(
             spyk(
                 object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
                 object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             ),
             spyk(
                 object : ConditionalMigration() {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                     override suspend fun shouldMigrate(fromVersion: Int): Boolean = true
                 }
             )
@@ -149,12 +145,12 @@ class MigratorTest {
         val migrations = listOf(
             spyk(
                 object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Result = Result.FAILED
+                    override suspend fun migrate(): Boolean = false
                 }
             ),
             spyk(
                 object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             )
         )
@@ -175,12 +171,12 @@ class MigratorTest {
         val migrations = listOf(
             spyk(
                 object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Result = Result.FAILED
+                    override suspend fun migrate(): Boolean = false
                 }
             ),
             spyk(
                 object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             )
         )
@@ -201,12 +197,12 @@ class MigratorTest {
         val migrations = listOf(
             spyk(
                 object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Result = Result.FAILED
+                    override suspend fun migrate(): Boolean = false
                 }
             ),
             spyk(
                 object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Result = Result.SUCCESS
+                    override suspend fun migrate(): Boolean = true
                 }
             )
         )
@@ -226,10 +222,10 @@ class MigratorTest {
     fun `migrate() returns failed on error`() {
         val migrations = listOf(
             object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Result = Result.FAILED
+                override suspend fun migrate(): Boolean = false
             },
             object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             }
         )
         val migrator = ConcreteMigrator(
@@ -247,10 +243,10 @@ class MigratorTest {
     fun `migrate() returns success on success`() {
         val migrations = listOf(
             object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             },
             object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             }
         )
         val migrator = ConcreteMigrator(
@@ -294,10 +290,10 @@ class MigratorTest {
     fun `onMigrateTo() is called after successful migration`() {
         val migrations = listOf(
             object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             },
             object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             }
         )
         val migrator = ConcreteMigrator(
@@ -315,10 +311,10 @@ class MigratorTest {
     fun `onMigrateTo() is called after failed migration`() {
         val migrations = listOf(
             object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Result = Result.SUCCESS
+                override suspend fun migrate(): Boolean = true
             },
             object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Result = Result.FAILED
+                override suspend fun migrate(): Boolean = false
             }
         )
         val migrator = ConcreteMigrator(

--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
@@ -118,7 +118,7 @@ class MigratorTest {
                 }
             ),
             spyk(
-                object : ConditionalMigration(4) {
+                object : ConditionalMigration() {
                     override suspend fun migrate(): Result = Result.SUCCESS
                     override suspend fun shouldMigrate(fromVersion: Int): Boolean = true
                 }

--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigratorTest.kt
@@ -1,304 +1,304 @@
 package com.boswelja.migration
 
-import io.mockk.coVerify
-import io.mockk.coVerifyOrder
-import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNull
 
 class MigratorTest {
 
     @Test
-    fun `migrate() succeeds with one migration`() {
-        // Set up dummy migrations
-        val migration = object : VersionMigration(1, 2) {
-            override suspend fun migrate(): Boolean = true
-        }
+    fun `runConstantMigrations does nothing with no migrations`(): Unit = runBlocking {
+        val migrationCount = 10
+        // Create a migrator for running tests
         val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 2,
-            migrations = listOf(migration)
+            1,
+            1,
+            false,
+            emptyList()
         )
 
-        val result = runBlocking { migrator.migrate() }
+        // Check with empty migration list
+        expectThat(
+            migrator.runConstantMigrations(1, emptyList())
+        ).isEqualTo(Result.NOT_NEEDED)
 
-        expectThat(result).isEqualTo(Result.SUCCESS)
+        // Check with migrations whose shouldMigrate returns false
+        val migrations = createConstantMigrations(
+            count = migrationCount,
+            shouldMigrate = { false },
+            migrateResult = { false }
+        )
+        expectThat(
+            migrator.runConstantMigrations(1, migrations)
+        ).isEqualTo(Result.NOT_NEEDED)
     }
 
     @Test
-    fun `migrate() fails when migration fails`() {
-        // Set up dummy migrations
-        val migration = object : VersionMigration(1, 2) {
-            override suspend fun migrate(): Boolean = false
-        }
+    fun `runConstantMigrations aborts when abortOnError is true`(): Unit = runBlocking {
+        val migrationCount = 10
+
+        // Create a migrator for running tests
         val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 2,
-            migrations = listOf(migration)
-        )
-
-        val result = runBlocking { migrator.migrate() }
-
-        expectThat(result).isEqualTo(Result.FAILED)
-    }
-
-    @Test
-    fun `migrate() runs migrations in the correct order`() {
-        // Create some ordered migrations
-        val orderedMigrations = listOf(
-            spyk(
-                object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            ),
-            spyk(
-                object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            ),
-            spyk(
-                object : VersionMigration(3, 4) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            )
-        )
-
-        // Create a Migrator with shuffled migrations
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 4,
-            migrations = orderedMigrations.shuffled()
+            1,
+            1,
+            true,
+            emptyList()
         )
 
         // Run migrations
-        runBlocking { migrator.migrate() }
+        var migrationExecutionCount = 0
+        val migrations = createConstantMigrations(
+            count = migrationCount,
+            shouldMigrate = { true },
+            migrateResult = {
+                migrationExecutionCount++
+                false
+            }
+        )
+        migrator.runConstantMigrations(1, migrations)
 
-        // Check migrations were executed in the right order
-        coVerifyOrder {
-            orderedMigrations[0].migrate()
-            orderedMigrations[1].migrate()
-            orderedMigrations[2].migrate()
+        // Verify only one migration was called
+        expectThat(migrationExecutionCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `runConstantMigrations returns FAILED on error`(): Unit = runBlocking {
+        val migrationCount = 10
+
+        // Create migrations
+        val migrations = createConstantMigrations(
+            count = migrationCount,
+            shouldMigrate = { true },
+            migrateResult = { false }
+        )
+
+        // Check with abortOnError = true
+        ConcreteMigrator(
+            1,
+            1,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(migrator.runConstantMigrations(1, migrations)).isEqualTo(Result.FAILED)
+        }
+
+        // Check with abortOnError = false
+        ConcreteMigrator(
+            1,
+            1,
+            false,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(migrator.runConstantMigrations(1, migrations)).isEqualTo(Result.FAILED)
         }
     }
 
     @Test
-    fun `migrate() returns not_needed when no migrations were run`() {
-        // Create a Migrator with no migrations
+    fun `runConstantMigrations throws exception if non-contant migrations are given`(): Unit = runBlocking {
+        // Create migrations
+        val migrations = createVersionedMigrations(
+            1,
+            2,
+            migrateResult = { true }
+        )
+
+        // Check with abortOnError = true
+        ConcreteMigrator(
+            1,
+            1,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThrows<IllegalArgumentException> {
+                migrator.runConstantMigrations(1, migrations)
+            }
+        }
+    }
+
+    @Test
+    fun `runConstantMigrations returns SUCCESS on successful migrations`(): Unit = runBlocking {
+        val migrationCount = 10
+
+        // Create migrations
+        val migrations = createConstantMigrations(
+            count = migrationCount,
+            shouldMigrate = { true },
+            migrateResult = { true }
+        )
+
+        // Create a migrator to use
+        ConcreteMigrator(
+            1,
+            1,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(migrator.runConstantMigrations(1, migrations)).isEqualTo(Result.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `runVersionedMigrations does nothing with no migrations`(): Unit = runBlocking {
+        val fromVersion = 1
+        val toVersion = 10
+        // Create a migrator for running tests
         val migrator = ConcreteMigrator(
-            oldVersion = 4,
-            currentVersion = 4,
-            migrations = emptyList()
+            toVersion,
+            toVersion,
+            false,
+            emptyList()
+        )
+
+        // Check with empty migration list
+        expectThat(
+            migrator.runVersionedMigrations(toVersion, emptyList())
+        ).isEqualTo(Result.NOT_NEEDED)
+
+        // Check with migrations that won't change the version
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion,
+            migrateResult = { true }
+        )
+        expectThat(
+            migrator.runVersionedMigrations(toVersion, migrations)
+        ).isEqualTo(Result.NOT_NEEDED)
+    }
+
+    @Test
+    fun `runVersionedMigrations aborts when abortOnError is true`(): Unit = runBlocking {
+        val fromVersion = 1
+        val toVersion = 10
+
+        // Create a migrator for running tests
+        val migrator = ConcreteMigrator(
+            fromVersion,
+            toVersion,
+            true,
+            emptyList()
         )
 
         // Run migrations
-        val result = runBlocking { migrator.migrate() }
+        var migrationExecutionCount = 0
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion,
+            migrateResult = {
+                migrationExecutionCount++
+                false
+            }
+        )
+        migrator.runVersionedMigrations(1, migrations)
 
-        expectThat(result).isEqualTo(Result.NOT_NEEDED)
+        // Verify only one migration was called
+        expectThat(migrationExecutionCount).isEqualTo(1)
     }
 
     @Test
-    fun `migrate() runs conditional migrations even when version hasn't changed`() {
-        // Create some ordered migrations
-        val migrations = listOf(
-            spyk(
-                object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            ),
-            spyk(
-                object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            ),
-            spyk(
-                object : ConditionalMigration() {
-                    override suspend fun migrate(): Boolean = true
-                    override suspend fun shouldMigrate(fromVersion: Int): Boolean = true
-                }
-            )
+    fun `runVersionedMigrations returns FAILED on error`(): Unit = runBlocking {
+        val fromVersion = 1
+        val toVersion = 10
+
+        // Create migrations
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion,
+            migrateResult = { false }
         )
 
-        // Create a Migrator with shuffled migrations
-        val migrator = ConcreteMigrator(
-            oldVersion = 4,
-            currentVersion = 4,
-            migrations = migrations
-        )
-
-        // Run migrations
-        runBlocking { migrator.migrate() }
-
-        // Check version migrations were not executed
-        coVerify(inverse = true) {
-            migrations[0].migrate()
-            migrations[1].migrate()
+        // Check with abortOnError = true
+        ConcreteMigrator(
+            fromVersion,
+            toVersion,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(migrator.runVersionedMigrations(1, migrations)).isEqualTo(Result.FAILED)
         }
-        // Check conditional migration was executed
-        coVerify { migrations[2].migrate() }
-    }
 
-    @Test
-    fun `abortOnError aborts on error when true`() {
-        val migrations = listOf(
-            spyk(
-                object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Boolean = false
-                }
-            ),
-            spyk(
-                object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            )
-        )
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
-            abortOnError = true,
-            migrations = migrations
-        )
-
-        runBlocking { migrator.migrate() }
-
-        coVerify(inverse = true) { migrations[1].migrate() }
-    }
-
-    @Test
-    fun `abortOnError continues on error when false`() {
-        val migrations = listOf(
-            spyk(
-                object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Boolean = false
-                }
-            ),
-            spyk(
-                object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            )
-        )
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
-            abortOnError = false,
-            migrations = migrations
-        )
-
-        runBlocking { migrator.migrate() }
-
-        coVerify { migrations[1].migrate() }
-    }
-
-    @Test
-    fun `abortOnError still returns failure`() {
-        val migrations = listOf(
-            spyk(
-                object : VersionMigration(1, 2) {
-                    override suspend fun migrate(): Boolean = false
-                }
-            ),
-            spyk(
-                object : VersionMigration(2, 3) {
-                    override suspend fun migrate(): Boolean = true
-                }
-            )
-        )
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
-            abortOnError = false,
-            migrations = migrations
-        )
-
-        val result = runBlocking { migrator.migrate() }
-
-        expectThat(result).isEqualTo(Result.FAILED)
-    }
-
-    @Test
-    fun `migrate() returns failed on error`() {
-        val migrations = listOf(
-            object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Boolean = false
-            },
-            object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Boolean = true
-            }
-        )
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
-            migrations = migrations
-        )
-
-        val result = runBlocking { migrator.migrate() }
-
-        expectThat(result).isEqualTo(Result.FAILED)
-    }
-
-    @Test
-    fun `migrate() returns success on success`() {
-        val migrations = listOf(
-            object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Boolean = true
-            },
-            object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Boolean = true
-            }
-        )
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
-            migrations = migrations
-        )
-
-        val result = runBlocking { migrator.migrate() }
-
-        expectThat(result).isEqualTo(Result.SUCCESS)
-    }
-
-    @Test
-    fun `migrate() throws exception when a migration path cannot be found`() {
-        val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 2,
-            migrations = emptyList()
-        )
-
-        expectThrows<IllegalStateException> {
-            migrator.migrate()
+        // Check with abortOnError = false
+        ConcreteMigrator(
+            fromVersion,
+            toVersion,
+            false,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(migrator.runVersionedMigrations(1, migrations)).isEqualTo(Result.FAILED)
         }
     }
 
     @Test
-    fun `migrate() throws exception when old version is greater than current version`() {
-        val migrator = ConcreteMigrator(
-            oldVersion = 2,
-            currentVersion = 1,
-            migrations = emptyList()
+    fun `runVersionedMigrations throws exception if contant migrations are given`(): Unit = runBlocking {
+        val migrationCount = 10
+        // Create migrations
+        val migrations = createConstantMigrations(
+            migrationCount,
+            shouldMigrate = { true },
+            migrateResult = { true }
         )
 
-        expectThrows<IllegalStateException> {
-            migrator.migrate()
+        // Check with abortOnError = true
+        ConcreteMigrator(
+            1,
+            1,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThrows<IllegalArgumentException> {
+                migrator.runVersionedMigrations(1, migrations)
+            }
         }
     }
 
     @Test
-    fun `onMigrateTo() is called after successful migration`() {
-        val migrations = listOf(
-            object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Boolean = true
-            },
-            object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Boolean = true
-            }
+    fun `runVersionedMigrations returns SUCCESS on successful migrations`(): Unit = runBlocking {
+        val fromVersion = 1
+        val toVersion = 10
+
+        // Create migrations
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion,
+            migrateResult = { true }
         )
+
+        // Create a migrator to use
+        ConcreteMigrator(
+            fromVersion,
+            toVersion,
+            true,
+            emptyList()
+        ).also { migrator ->
+            // Check result
+            expectThat(
+                migrator.runVersionedMigrations(fromVersion, migrations)
+            ).isEqualTo(Result.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `onMigratedTo is called after successful migration`() {
+        val fromVersion = 1
+        val toVersion = 3
+
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion
+        ) { true }
+
         val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
+            oldVersion = fromVersion,
+            currentVersion = toVersion,
             migrations = migrations
         )
 
@@ -308,23 +308,56 @@ class MigratorTest {
     }
 
     @Test
-    fun `onMigrateTo() is called after failed migration`() {
-        val migrations = listOf(
-            object : VersionMigration(1, 2) {
-                override suspend fun migrate(): Boolean = true
-            },
-            object : VersionMigration(2, 3) {
-                override suspend fun migrate(): Boolean = false
-            }
-        )
+    fun `onMigratedTo is called after failed migration`() {
+        val fromVersion = 1
+        val toVersion = 3
+
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion
+        ) { false }
+
         val migrator = ConcreteMigrator(
-            oldVersion = 1,
-            currentVersion = 3,
+            oldVersion = fromVersion,
+            currentVersion = toVersion,
             migrations = migrations
         )
 
         runBlocking { migrator.migrate() }
 
-        expectThat(migrator.migratedTo).isEqualTo(2)
+        expectThat(migrator.migratedTo).isEqualTo(fromVersion)
+    }
+
+    @Test
+    fun `onMigratedTo is not called if no migrations were run`() {
+        val fromVersion = 1
+        val toVersion = 3
+
+        val migrations = createVersionedMigrations(
+            fromVersion,
+            toVersion
+        ) { false }
+
+        val migrator = ConcreteMigrator(
+            oldVersion = toVersion,
+            currentVersion = toVersion,
+            migrations = migrations
+        )
+
+        runBlocking { migrator.migrate() }
+
+        expectThat(migrator.migratedTo).isNull()
+    }
+
+    @Test
+    fun `migrate throws IllegalStateException if getOldVersion returns higher than currentVersion`() {
+        val migrator = ConcreteMigrator(
+            oldVersion = 2,
+            currentVersion = 1,
+            migrations = emptyList()
+        )
+        expectThrows<IllegalStateException> {
+            migrator.migrate()
+        }
     }
 }

--- a/migration-core/src/test/kotlin/com/boswelja/migration/ResultTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/ResultTest.kt
@@ -1,0 +1,41 @@
+package com.boswelja.migration
+
+import org.junit.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class ResultTest {
+
+    @Test
+    fun `combineResults returns SUCCESS if all passed are SUCCESS`() {
+        val results = arrayOf(
+            Result.SUCCESS,
+            Result.SUCCESS,
+            Result.SUCCESS
+        )
+
+        expectThat(combineResults(*results)).isEqualTo(Result.SUCCESS)
+    }
+
+    @Test
+    fun `combineResults returns FAILED if one passed is FAILED`() {
+        val results = arrayOf(
+            Result.SUCCESS,
+            Result.FAILED,
+            Result.SUCCESS
+        )
+
+        expectThat(combineResults(*results)).isEqualTo(Result.FAILED)
+    }
+
+    @Test
+    fun `combineResults returns NOT_NEEDED if all passed are NOT_NEEDED`() {
+        val results = arrayOf(
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED,
+            Result.NOT_NEEDED
+        )
+
+        expectThat(combineResults(*results)).isEqualTo(Result.NOT_NEEDED)
+    }
+}

--- a/migration-core/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
@@ -13,7 +13,7 @@ class VersionMigrationTest {
         val fromVersion = 1
         val toVersion = 2
         val migration = object : VersionMigration(fromVersion, toVersion) {
-            override suspend fun migrate(): Result = Result.SUCCESS
+            override suspend fun migrate(): Boolean = true
         }
 
         val shouldMigrate = runBlocking { migration.shouldMigrate(fromVersion) }
@@ -25,7 +25,7 @@ class VersionMigrationTest {
         val fromVersion = 1
         val toVersion = 2
         val migration = object : VersionMigration(fromVersion, toVersion) {
-            override suspend fun migrate(): Result = Result.SUCCESS
+            override suspend fun migrate(): Boolean = true
         }
 
         val shouldMigrate = runBlocking { migration.shouldMigrate(toVersion) }


### PR DESCRIPTION
breaking: This change modifies the ConditionalMigration structure, as well as makes changes to the base Migration interface.
I've set up a more proper structure for running conditional migrations, which also doesn't require specifying a `toVersion` anymore, which means conditional migrations are "truly conditional".
Internally, migrations that don't specify a `toVersion` are referred to as "Constant migrations", since they won't modify the Migrator version. Migrations that specify `toVersion` are classified as "Versioned migrations", whether they implement `VersionedMigration` or not.

Resolves #10 